### PR TITLE
Added mutable-content to IOSNotificationItem to support Notification …

### DIFF
--- a/Sources/NotificationPusher.swift
+++ b/Sources/NotificationPusher.swift
@@ -98,7 +98,7 @@ public enum IOSNotificationItem {
     /// custom payload data
 	case customPayload(String, Any)
     /// apn mutable-content key
-        case mutableContent
+    case mutableContent
 }
 
 enum IOSItemId: UInt8 {
@@ -413,9 +413,9 @@ public class NotificationPusher {
 				aps["category"] = s
 			case .customPayload(let s, let a):
 				dict[s] = a
-                    case .mutableContent:
-                        aps["mutable-content"] = 1
-                }
+            case .mutableContent:
+                aps["mutable-content"] = 1
+            }
 		}
 		
 		if let ab = alertBody {

--- a/Sources/NotificationPusher.swift
+++ b/Sources/NotificationPusher.swift
@@ -97,6 +97,8 @@ public enum IOSNotificationItem {
 	case category(String)
     /// custom payload data
 	case customPayload(String, Any)
+    /// apn mutable-content key
+    case mutableContent
 }
 
 enum IOSItemId: UInt8 {
@@ -411,7 +413,9 @@ public class NotificationPusher {
 				aps["category"] = s
 			case .customPayload(let s, let a):
 				dict[s] = a
-			}
+            case .mutableContent:
+                aps["mutable-content"] = 1
+            }
 		}
 		
 		if let ab = alertBody {

--- a/Sources/NotificationPusher.swift
+++ b/Sources/NotificationPusher.swift
@@ -98,7 +98,7 @@ public enum IOSNotificationItem {
     /// custom payload data
 	case customPayload(String, Any)
     /// apn mutable-content key
-    case mutableContent
+        case mutableContent
 }
 
 enum IOSItemId: UInt8 {
@@ -413,9 +413,9 @@ public class NotificationPusher {
 				aps["category"] = s
 			case .customPayload(let s, let a):
 				dict[s] = a
-            case .mutableContent:
-                aps["mutable-content"] = 1
-            }
+                    case .mutableContent:
+                        aps["mutable-content"] = 1
+                }
 		}
 		
 		if let ab = alertBody {


### PR DESCRIPTION
Added mutable-content to IOSNotificationItem to support Notification Service Extensions.
The mutable-content flag must be set in the aps payload in order to support notification service extensions from remote notifications.
