### PR TITLE
Update 'Obtain APNs Auth Key' section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ When the device obtains its ID it will need to transmit it to **your** server. Y
 Obtain APNs Auth Key
 --------
 
-To connect your server to Apple's push notification system you will first need to obtain an "APNs Auth Key". This key is used on your server to configure its APNs access. You can generate this key through your Apple developer account portal. Log in to your developer account and choose "Certificates, IDs &amp; Profiles" from the menu. Then, under "Certificates", choose "APNs Auth Key".
+To connect your server to Apple's push notification system you will first need to obtain an "APNs Auth Key". This key is used on your server to configure its APNs access. You can generate this key through your Apple developer account portal. Log in to your developer account and choose "Certificates, IDs &amp; Profiles" from the menu. Then, under "Keys", choose "All".
 
-If you haven't already created and downloaded the auth key, click "+" to create a new one. Make sure you select **Apple Push Notification service SSL (Sandbox & Production)**. This one key can be used for both development or production and can be used for any of your iOS/macOS apps.
+If you haven't already created and downloaded the auth key, click "+" to create a new one. Enter a name for the key and make sure you select **Apple Push Notifications service (APNs)**. This one key can be used for both development or production and can be used for any of your iOS/macOS apps.
 
-Click "Continue" and you will be given a chance to download the **private key**. You must download this key now and **save the file**. Also copy the "Key ID" shown in the same view. This will be a 10 character string.
+Click "Continue", then "Confirm", then you will be given a chance to download the **private key**. You must download this key now and **save the file**. Also copy the "Key ID" shown in the same view. This will be a 10 character string.
 
 Finally you will need to locate your developer team id. Click "Account" near the window's top. Select "Membership" in the menu. You will then be shown much of your personal information, including "Team ID". This is another 10 character string. Copy this value.
 


### PR DESCRIPTION
Update 'Obtain APNs Auth Key' section in README.md to accurately reflect Apple Developer Portal current organization. APNs Auth Keys are now in a 'Keys' section rather than in 'Certificates'.