### PR TITLE
Update deprecated Hashable protocol conformance

### DIFF
--- a/Sources/PerfectNotifications/HTTP/HTTPHeaders.swift
+++ b/Sources/PerfectNotifications/HTTP/HTTPHeaders.swift
@@ -33,9 +33,9 @@ enum HTTPRequestHeader {
 		case xB3TraceId, xB3SpanId, xB3ParentSpanId
 		case custom(name: String)
 		
-		var hashValue: Int {
-			return self.standardName.lowercased().hashValue
-		}
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(standardName.lowercased())
+        }
 		
 		var standardName: String {
 			switch self {

--- a/Sources/PerfectNotifications/HTTP/HTTPMethod.swift
+++ b/Sources/PerfectNotifications/HTTP/HTTPMethod.swift
@@ -59,10 +59,10 @@ enum HTTPMethod: Hashable, CustomStringConvertible {
 		}
 	}
 	
-	/// Method String hash value
-	var hashValue: Int {
-		return self.description.hashValue
-	}
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(description)
+    }
 	
 	/// The method as a String
 	var description: String {


### PR DESCRIPTION
Update the deprecated `hashValue` on `HTTPRequestHeader.Name` and `HTTPMethod` to use `hash(into:)`